### PR TITLE
Lui/textinput styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,8 @@
 import './index.css'
 import { FirstButton } from './components/Button'
-import { TextInput } from './components/TextInput'
-import { useState } from 'react'
+import { LuiExamples } from './LuiExamples'
 
 function App() {
-
-  const [dummyInputText, setDummyInputText] = useState<string>("")
-  const headerStyle = "text-4xl text-blue-500 font-bold underline";
-  const subheadStyle = "text-xl text-purple-700 font-bold";
-  const sampleIcon = "icon.png"
-
 
   return (
     <>
@@ -19,37 +12,8 @@ function App() {
         </div>
         <FirstButton />
       </div>
-      <div key="text-input component states">
-        <div className={headerStyle}>
-          Text Input
-        </div>
-        <div className={subheadStyle}>
-          Default with minimum props (value & onChange):
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} />
-        </div>
-        <div className={subheadStyle}>
-          Other states:
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='Disabled state' isDisabled={true} />
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='Password version' isPassword={true} />
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='State = Error :(' validationState="error" />
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='State = Success :)' validationState="success" />
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='prefixIcon' prefixIcon={sampleIcon} />
-        </div>
-        <div>
-          <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='suffixIcon' suffixIcon={sampleIcon} />
-        </div>
+      <div>
+        <LuiExamples />
       </div>
 
 

--- a/src/LuiExamples.tsx
+++ b/src/LuiExamples.tsx
@@ -4,8 +4,8 @@ import { TextInput } from "./components/TextInput";
 export const LuiExamples = () => {
 
     const [dummyInputText, setDummyInputText] = useState<string>("")
-    const headerStyle = "text-4xl text-blue-500 font-bold underline";
-    const subheadStyle = "text-xl text-purple-700 font-bold";
+    const headerStyle = "text-4xl text-teal-500 font-bold m-3";
+    const subheadStyle = "text-xl text-purple-700 font-bold m-3";
     const sampleIcon = "icon.png"
 
     return (

--- a/src/LuiExamples.tsx
+++ b/src/LuiExamples.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { TextInput } from "./components/TextInput";
+
+export const LuiExamples = () => {
+
+    const [dummyInputText, setDummyInputText] = useState<string>("")
+    const headerStyle = "text-4xl text-blue-500 font-bold underline";
+    const subheadStyle = "text-xl text-purple-700 font-bold";
+    const sampleIcon = "icon.png"
+
+    return (
+        <>
+            <div key="text-input component states">
+                <div className={headerStyle}>
+                    Text Input
+                </div>
+                <div className={subheadStyle}>
+                    Default with minimum props (value & onChange):
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} />
+                </div>
+                <div className={subheadStyle}>
+                    Other states:
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='Disabled state' isDisabled={true} />
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='Password version' isPassword={true} />
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='State = Error :(' validationState="error" />
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='State = Success :)' validationState="success" />
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='prefixIcon' prefixIcon={sampleIcon} />
+                </div>
+                <div>
+                    <TextInput value={dummyInputText} onChange={setDummyInputText} placeholderText='suffixIcon' suffixIcon={sampleIcon} />
+                </div>
+            </div>
+        </>
+    )
+}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -59,14 +59,14 @@ export const TextInput = ({ value, onChange, placeholderText, isPassword, isDisa
                 <div className="flex flex-col">
                     {prefixIcon && <img src={prefixIcon} alt="prefix icon" className={iconImg} />}
                 </div>
-                <div className="flex flex-col">
+                <div className="flex flex-col flex-grow ">
                     <input
                         type={isPassword ? "password" : "text"}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}
                         placeholder={placeholderText}
                         disabled={isDisabled}
-                        className="flex-grow p-3 rounded"
+                        className="p-3 rounded"
                     />
                 </div>
                 <div className="flex flex-col">

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -39,13 +39,15 @@ type TextInputProps = {
  */
 export const TextInput = ({ value, onChange, placeholderText, isPassword, isDisabled, prefixIcon, suffixIcon, validationState }: TextInputProps) => {
 
-    const sharedStyle = "rounded border p-2 m-2";
+    // Styles for Container
+    const sharedStyle = "flex rounded border m-2";
     const regStyle = sharedStyle;
     const successStyle = sharedStyle + " border-green-500";
     const errorStyle = sharedStyle + " border-red-500";
 
-    const iconSpan = "inline-block";
-    const iconImg = "h-4 w-4";
+    const activeStyle = (validationState === "error") ? errorStyle : validationState === "success" ? successStyle : regStyle
+
+    const iconImg = "h-6 w-6 m-2";
 
     if (!placeholderText) {
         placeholderText = "Enter text here...";
@@ -53,21 +55,23 @@ export const TextInput = ({ value, onChange, placeholderText, isPassword, isDisa
 
     return (
         <>
-            <div>
-                {prefixIcon && <span className={iconSpan}>
-                    <img src={prefixIcon} alt="prefix icon" className={iconImg} />
-                </span>}
-                <input
-                    type={isPassword ? "password" : "text"}
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                    placeholder={placeholderText}
-                    disabled={isDisabled}
-                    className={validationState === "error" ? errorStyle : validationState === "success" ? successStyle : regStyle}
-                />
-                {suffixIcon && <span className={iconSpan}>
-                    <img src={suffixIcon} alt="suffix icon" className={iconImg} />
-                </span>}
+            <div className={activeStyle}>
+                <div className="flex flex-col">
+                    {prefixIcon && <img src={prefixIcon} alt="prefix icon" className={iconImg} />}
+                </div>
+                <div className="flex flex-col">
+                    <input
+                        type={isPassword ? "password" : "text"}
+                        value={value}
+                        onChange={(e) => onChange(e.target.value)}
+                        placeholder={placeholderText}
+                        disabled={isDisabled}
+                        className="flex-grow p-3 rounded"
+                    />
+                </div>
+                <div className="flex flex-col">
+                    {suffixIcon && <img src={suffixIcon} alt="suffix icon" className={iconImg} />}
+                </div>
             </div>
         </>
     );

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -39,15 +39,33 @@ type TextInputProps = {
  */
 export const TextInput = ({ value, onChange, placeholderText, isPassword, isDisabled, prefixIcon, suffixIcon, validationState }: TextInputProps) => {
 
-    // Styles for Container
-    const sharedStyle = "flex rounded border m-2";
-    const regStyle = sharedStyle;
-    const successStyle = sharedStyle + " border-green-500";
-    const errorStyle = sharedStyle + " border-red-500";
+    const containerStyle = `
+        relative 
+        flex 
+        flex-col 
+        flex-grow 
+        rounded 
+        border 
+        m-2 
+        ${validationState === "success" ? "border-green-500" : ""} 
+        ${validationState === "error" ? "border-red-500" : ""}
+    `;
 
-    const activeStyle = (validationState === "error") ? errorStyle : validationState === "success" ? successStyle : regStyle
+    // Padding notes:
+    // w-6 + m-3 + m-3 = *-12 (48px) on the icon
+    // this must equal the pl-12 or pr-12 padding used in inputPadding box when icon appears
+    // 
+    // Transform notes:
+    // top-1/2 puts top edge at 50% of containing element's height
+    // transform -translate-y-1/2 ...translates element vertically by -50% of its own height
+    const iconStyle = "h-6 w-6 mx-3 top-1/2 transform -translate-y-1/2";
 
-    const iconImg = "h-6 w-6 m-2";
+    const inputPadding = `
+        rounded 
+        p-3 
+        ${prefixIcon ? "pl-12" : ""} 
+        ${suffixIcon ? "pr-12" : ""}
+    `;
 
     if (!placeholderText) {
         placeholderText = "Enter text here...";
@@ -55,23 +73,17 @@ export const TextInput = ({ value, onChange, placeholderText, isPassword, isDisa
 
     return (
         <>
-            <div className={activeStyle}>
-                <div className="flex flex-col">
-                    {prefixIcon && <img src={prefixIcon} alt="prefix icon" className={iconImg} />}
-                </div>
-                <div className="flex flex-col flex-grow ">
-                    <input
-                        type={isPassword ? "password" : "text"}
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                        placeholder={placeholderText}
-                        disabled={isDisabled}
-                        className="p-3 rounded"
-                    />
-                </div>
-                <div className="flex flex-col">
-                    {suffixIcon && <img src={suffixIcon} alt="suffix icon" className={iconImg} />}
-                </div>
+            <div className={containerStyle}>
+                {prefixIcon && <img src={prefixIcon} alt="input icon (prefix)" className={`${iconStyle} absolute left-0 `} />}
+                <input
+                    type={isPassword ? "password" : "text"}
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder={placeholderText}
+                    disabled={isDisabled}
+                    className={inputPadding}
+                />
+                {suffixIcon && <img src={suffixIcon} alt="input icon (suffix)" className={`${iconStyle} absolute right-0`} />}
             </div>
         </>
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dee287ce65d30a5258d1b09e9d17694032727a20  | 
|--------|--------|

### Summary:
Refactored `TextInput` component styling and moved examples to a new `LuiExamples` component for better code organization.

**Key points**:
- Refactored `TextInput` component styling in `src/components/TextInput.tsx`.
- Added `containerStyle`, `iconStyle`, and `inputPadding` for better styling control.
- Moved `TextInput` examples from `src/App.tsx` to new `src/LuiExamples.tsx` component.
- Updated `src/App.tsx` to use `LuiExamples` component.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->